### PR TITLE
feat: added soft anti affinity

### DIFF
--- a/iac/cloud/openstack/lib/openstack-servergroup/main.tf
+++ b/iac/cloud/openstack/lib/openstack-servergroup/main.tf
@@ -1,4 +1,4 @@
 resource "openstack_compute_servergroup_v2" "servergroup" {
   name     = "${var.naming_prefix}${var.name}"
-  policies = ["anti-affinity"]
+  policies = var.cp_server_group_affinity
 }

--- a/iac/cloud/openstack/lib/openstack-servergroup/variables.tf
+++ b/iac/cloud/openstack/lib/openstack-servergroup/variables.tf
@@ -5,3 +5,8 @@ variable "name" {
 variable "naming_prefix" {
   type = string
 }
+
+variable "cp_server_group_affinity" {
+  type    = list(string)
+  default = []
+}

--- a/iac/cloud/openstack/openstack-nova/main.tf
+++ b/iac/cloud/openstack/openstack-nova/main.tf
@@ -155,6 +155,7 @@ module "servergroup_master" {
   source = "../lib/openstack-servergroup"
   name          = "master"
   naming_prefix = var.naming_prefix
+  cp_server_group_affinity       = var.cp_server_group_affinity
 }
 
 module "user_data_ubuntu" {

--- a/iac/cloud/openstack/openstack-nova/variables.tf
+++ b/iac/cloud/openstack/openstack-nova/variables.tf
@@ -80,6 +80,11 @@ variable "create_container" {
   default = false
 }
 
+variable "cp_server_group_affinity" {
+  type    = list(string)
+  default = ["soft-anti-affinity"]
+}
+
 variable "csi_enabled" {
   type    = bool
   default = false


### PR DESCRIPTION
Expose the ability to define the Control plane Server Group Affinity Policy by passing `cp_server_group_affinity` to the `openstack-nova` module.
