### PR TITLE
feat: mtu for iac network

### DIFF
--- a/iac/cloud/openstack/lib/user_data-ubuntu/ubuntu-init24.tpl
+++ b/iac/cloud/openstack/lib/user_data-ubuntu/ubuntu-init24.tpl
@@ -43,10 +43,12 @@ users:
   - default
   - name: ${ssh_user}
     sudo: ALL=(ALL) NOPASSWD:ALL
+%{if length(ssh_authorized_keys) > 0~}
     ssh_authorized_keys:
 %{for key in ssh_authorized_keys~}
       - ${key}
 %{endfor~}
+%{endif~}
 write_files:
 %{if pf9_onboard == true~}
   - content: |

--- a/iac/cloud/openstack/openstack-nova/network.tf
+++ b/iac/cloud/openstack/openstack-nova/network.tf
@@ -2,6 +2,7 @@ resource "openstack_networking_network_v2" "network" {
   count          = var.vlan_id == "" ? 1 : 0
   name           = "${var.naming_prefix}k8s"
   admin_state_up = "true"
+  mtu            = var.mtu
 }
 
 resource "openstack_networking_subnet_v2" "subnet" {

--- a/iac/cloud/openstack/openstack-nova/variables.tf
+++ b/iac/cloud/openstack/openstack-nova/variables.tf
@@ -228,6 +228,12 @@ variable "network_id" {
   default = ""
 }
 
+variable "mtu" {
+  type        = number
+  default     = null
+  description = "MTU value for the network. If not set, the cloud provider default is used."
+}
+
 variable "node_cidr_mask_size" {
   type    = string
   default = ""


### PR DESCRIPTION
Feat: Expose the option to set the network MTU
Fix: cloud-init would fail if no ssh_authorized_keys was defined